### PR TITLE
Improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+BINARY_NAME=hpsm
+LIB_NAME=libhpsm.so
+
+build_lib:
+	go build -o ${LIB_NAME}  -buildmode=c-shared lib/libhpsm.go
+
+cli:
+	go build -o ${BINARY_NAME} main.go
+
+clean: 
+	rm hpsm
+	rm libhpsm.so
+
+install:
+	cp ${LIB_NAME} /usr/lib
+	cp ${BINARY_NAME} /usr/bin

--- a/lib/libhpsm.go
+++ b/lib/libhpsm.go
@@ -12,6 +12,7 @@ import "C"
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strconv"
 	"unsafe"
@@ -174,7 +175,11 @@ func localProcessHPSM(local []uint8, remoteMd5 string, Threshold uint32) []model
 	//Remote access to API
 
 	MD5 := remoteMd5
-	GetFileContent("https://osskb.org/api/file_contents/"+MD5, "/tmp/"+MD5)
+	srcEndpoint := os.Getenv("SRC_URL")
+	if srcEndpoint == "" {
+		srcEndpoint = "https://osskb.org/api/file_contents/"
+	}
+	GetFileContent(srcEndpoint+MD5, "/tmp/"+MD5)
 	hashRemote := proc.GetLineHashes("/tmp/" + MD5)
 	u.Rm("/tmp/" + MD5)
 	return proc.Compare(local, hashRemote, uint32(5))

--- a/main.go
+++ b/main.go
@@ -45,9 +45,9 @@ func main() {
 
 	if len(os.Args) < 2 {
 		fmt.Println("Available command")
-		fmt.Println("hash <filename>: get lines hashes in one line from file")
-		fmt.Println("wfp  <filename>: Fingerprints the file and adds the hash line")
-		fmt.Println("compare <localFile> <remoteFile|md5> [MD5]: Compare <localFile> against <remoteFile> or with <MD5>. MD5 flag should be included")
+		fmt.Println("hash <filename>: gets line hashes in one line from file")
+		fmt.Println("wfp  <filename>: Fingerprints the file and adds the hpsm= line")
+		fmt.Println("compare <localFile> <remoteFile|md5> [MD5]: Compares <localFile> against <remoteFile> or with remote <MD5>.")
 		os.Exit(1)
 	}
 	if os.Args[1] == "hash" {
@@ -83,9 +83,14 @@ func main() {
 
 		//setColor(2)
 		var remote []byte
-
-		if len(os.Args) == 5 && os.Args[4] == "MD5" {
-			utils.Wget("https://osskb.org/api/file_contents/"+os.Args[3], "/tmp/"+os.Args[3])
+		var md5Int [2]uint
+		matched, _ := fmt.Sscanf(os.Args[3], "%16x%16x", &md5Int[0], &md5Int[1])
+		if matched == 2 {
+			srcEndpoint := os.Getenv("SRC_URL")
+			if srcEndpoint == "" {
+				srcEndpoint = "https://osskb.org/api/file_contents/"
+			}
+			utils.Wget(srcEndpoint+os.Args[3], "/tmp/"+os.Args[3])
 			remote, _ = os.ReadFile("/tmp/" + os.Args[3])
 			utils.Rm("/tmp/" + os.Args[3])
 		} else {

--- a/utils/fileutils.go
+++ b/utils/fileutils.go
@@ -11,21 +11,17 @@ import (
 
 func Wget(url string, filepath string) error {
 	// run shell `wget URL -O filepath`
-	fmt.Printf("downloading %s -> %s\n", url, filepath)
+	//fmt.Printf("downloading %s -> %s\n", url, filepath)
 	cmd := exec.Command("wget", url, "-O", filepath)
-	//	cmd.Stdout = os.Stdout
-	//cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 func Mkdir(path string) error {
-	// run shell `wget URL -O filepath`
 	cmd := exec.Command("mkdir", "-p", path)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	return cmd.Run()
 }
 func Rm(file string) error {
-	// run shell `wget URL -O filepath`
 	cmd := exec.Command("rm", file)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -35,8 +31,6 @@ func Rm(file string) error {
 func Unzip(path string, dest string) error {
 	cmd := exec.Command("unzip", "-PSecret", "-n", path+"/master.zip", "-d", dest)
 	fmt.Printf("Extacting %s\n", path)
-	//cmd.Stdout = os.Stdout
-	//cmd.Stderr = os.Stderr
 	return cmd.Run()
 
 }


### PR DESCRIPTION
* Added makefile automation
* Added support to SRC_URL enviromental variable to set endpoint of sources
* Removes the MD5 mandatory switch on compare subcommand on CLI. Now, a remote file can be directly comprared with:
 hpsm compare <localFile> <remoteMD5>
