### PR TITLE
Change default scanoss_sources_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ The functionality is available by:
 * **go module** A go package (Coming soon).
 
 ## Remote Files
-By default, files from *"https://osskb.org/api/file_contents/"* are retrieved. If other sources server is used, the environmental variable **SCANOSS_FILE_CONTENTS_URL** must be used. Eg:
+By default, files from *localhost/api/file_contents* are retrieved. If other sources server is used, the environment variable **SCANOSS_FILE_CONTENTS_URL** must be used. Eg:
   
- ``export  SCANOSS_FILE_CONTENTS_URL=https://osskb.org/api/file_contents/``
+ ``export  SCANOSS_FILE_CONTENTS_URL=https://api.scanoss.com/file_contents/``
 
 You can also set the environmental variable `SCANOSS_API_KEY` that will be passed as the `X-Session` header.
 

--- a/lib/libhpsm.go
+++ b/lib/libhpsm.go
@@ -166,7 +166,7 @@ func localProcessHPSM(local []uint8, remoteMd5 string, Threshold uint32) []model
 	MD5 := remoteMd5
 	srcEndpoint := os.Getenv("SCANOSS_FILE_CONTENTS_URL")
 	if srcEndpoint == "" {
-		srcEndpoint = "https://api.osskb.org/file_contents/"
+		srcEndpoint = "localhost/api/file_contents/"
 	}
 	err := GetFileContent(srcEndpoint+MD5, "/tmp/"+MD5)
 


### PR DESCRIPTION
Switched default from api.osskb.org to localhost/api/file_contents