### PR TITLE
fix/SP-2267 Normalize base path URLs to handle trailing slashes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ version.txt
 hpsm
 libhpsm.so
 libhpsm.h
+
+
+.idea

--- a/lib/libhpsm.go
+++ b/lib/libhpsm.go
@@ -168,6 +168,7 @@ func localProcessHPSM(local []uint8, remoteMd5 string, Threshold uint32) []model
 	if srcEndpoint == "" {
 		srcEndpoint = "http://localhost:5443/file_contents/"
 	}
+	srcEndpoint = u.NormalizeSourceURL(srcEndpoint)
 	err := GetFileContent(srcEndpoint+MD5, "/tmp/"+MD5)
 
 	if err == nil {

--- a/main.go
+++ b/main.go
@@ -83,6 +83,7 @@ func main() {
 			if srcEndpoint == "" {
 				srcEndpoint = "http://localhost:5443/file_contents/"
 			}
+			srcEndpoint = utils.NormalizeSourceURL(srcEndpoint)
 			utils.Wget(srcEndpoint+os.Args[3], "/tmp/"+os.Args[3])
 			remote, _ = os.ReadFile("/tmp/" + os.Args[3])
 			utils.Rm("/tmp/" + os.Args[3])

--- a/utils/url_utils.go
+++ b/utils/url_utils.go
@@ -1,0 +1,17 @@
+package utils
+
+import "strings"
+
+// NormalizeSourceURL processes a URL to ensure consistent formatting
+// Current implementation:
+// 1. Trims leading spaces with TrimLeft
+// 2. Trims trailing spaces AND slashes with TrimRight
+// 3. Adds a single trailing slash to ensure consistent URL format
+//
+// This approach standardizes URLs by ensuring exactly one trailing slash,
+// preventing double-slash issues when concatenating paths.
+func NormalizeSourceURL(baseurl string) string {
+	leftTrimmedUrl := strings.TrimLeft(baseurl, " ")
+	trimmedUrl := strings.TrimRight(leftTrimmedUrl, "/ ")
+	return trimmedUrl + "/"
+}

--- a/utils/url_utils_test.go
+++ b/utils/url_utils_test.go
@@ -1,0 +1,62 @@
+package utils
+
+import "testing"
+
+func TestNormalizeSourceURL(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "Basic URL without trailing slash",
+			input:    "https://api.scanoss.com/file_contents",
+			expected: "https://api.scanoss.com/file_contents/", // Current function adds a slash
+		},
+		{
+			name:     "URL with trailing slash",
+			input:    "https://api.scanoss.com/file_contents/",
+			expected: "https://api.scanoss.com/file_contents/", // Current function leaves this unchanged
+		},
+		{
+			name:     "URL with leading spaces",
+			input:    "  https://api.scanoss.com/file_contents",
+			expected: "https://api.scanoss.com/file_contents/", // Current function trims spaces and adds slash
+		},
+		{
+			name:     "URL with trailing spaces",
+			input:    "https://api.scanoss.com/file_contents  ",
+			expected: "https://api.scanoss.com/file_contents/", // Current function trims spaces and adds slash
+		},
+		{
+			name:     "URL with leading and trailing spaces",
+			input:    "  https://api.scanoss.com/file_contents  ",
+			expected: "https://api.scanoss.com/file_contents/", // Current function trims spaces and adds slash
+		},
+		{
+			name:     "URL with trailing slash and spaces",
+			input:    "https://api.scanoss.com/file_contents/  ",
+			expected: "https://api.scanoss.com/file_contents/", // Current function trims spaces and keeps slash
+		},
+		{
+			name:     "Multiple trailing slashes",
+			input:    "https://api.scanoss.com/file_contents///",
+			expected: "https://api.scanoss.com/file_contents/", // Current function normalize the trailing slash
+		},
+		{
+			name:     "Multiple trailing slashes with spaces",
+			input:    "    https://api.scanoss.com/file_contents///     ",
+			expected: "https://api.scanoss.com/file_contents/", // Current function normalize the trailing slash
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			result := NormalizeSourceURL(tc.input)
+			if result != tc.expected {
+				t.Errorf("normalizeSourceURL(%q) = %q, expected %q", tc.input, result, tc.expected)
+			}
+
+		})
+	}
+}


### PR DESCRIPTION
### WHAT

* Normalize base source path to handle URLs with or without trailing slashes
* Adds .idea to .gitignore